### PR TITLE
move to peer dependencies and fix test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.120.0.tgz",
       "integrity": "sha512-XbP4OYPx7Kj2YU/wTfRv/C0YM1rf296fZcmqk2Ld6MWKTrhslUNGw+rQbLhAEXIH+TQFgVLBy48EkqKhS6uQdA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "@aws-cdk/cx-api": "1.120.0",
@@ -30,6 +31,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.120.0.tgz",
       "integrity": "sha512-uSGltS2ozGQY9iuDyGOyZ8u+aKdGYn+kWSZ1JDCMHLgLj3p/yNR6EPC2eE5QhWHKLwuE8/eVARCBGoTtCEs3uQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-certificatemanager": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -50,6 +52,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.120.0.tgz",
       "integrity": "sha512-nQWBzLhlBJqD0kGZytSXsUYL5g6Jf/uJK4YCn/ERhlEy0I5z5+yolZDH2vkSKydgzRNdm6xbfdv3EJQb/ob5nw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-certificatemanager": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -63,6 +66,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations/-/aws-apigatewayv2-integrations-1.120.0.tgz",
       "integrity": "sha512-BGSZ7uQh5XT+6wLMzocyNWsob6lHFzv7sCml0tT0JWO+DAFtAvutYahYutWCtzH+942FFYRnhejWcoVRj3Zzug==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-apigatewayv2": "1.120.0",
         "@aws-cdk/aws-ec2": "1.120.0",
@@ -78,6 +82,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.120.0.tgz",
       "integrity": "sha512-dBo36TfhTifpMcuQG4O4XI11lDZaoI+kDKLHjGx61i6Yed+xcOq4YHJAyB0VEiXdpIuMwfEyDlHzzFNqxnEuGA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-autoscaling-common": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -90,6 +95,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.120.0.tgz",
       "integrity": "sha512-NmivBFnOtaLpzFOnJ17Tva6oCFyuz+ssN0whLYNAgkyWQAAaT1/UqLp/+jiAovmASjtP40CvKGet2SpPJ7R69g==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-autoscaling-common": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -106,6 +112,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.120.0.tgz",
       "integrity": "sha512-9iuHMyNGrXnD8fjh/4ObgOM0GZ+BpM/a2L/RF0O3UrmXGQx6nnMHztySle80ngqELLQqdybB9flrApO8mrUVpA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -116,6 +123,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.120.0.tgz",
       "integrity": "sha512-o/lF9k66gpEDhvV1vBS4qjM5HJW8rQdyIiGIkoWfCnkJT3Ad6sxVPz9NQFXNiQgahPO0xbK7V5hLLRSEzdGCnw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-autoscaling": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -132,6 +140,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.120.0.tgz",
       "integrity": "sha512-tMAN4pw/cRdaZ/KLQZLb1g4btI7WQTMEMGW9jEPzJ8LoaRPRygFQnvWDSjb5iOsFBeT3D6vI4dzZr5r2jO69RQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -145,6 +154,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.120.0.tgz",
       "integrity": "sha512-Mdgh5Lo0JH+wHnjQCfU0a+sATAuLUbOMpnyqRmsNb1KGoPuW1lgAqBwS1oF6ciFTvnrjq+fogX2kEPmYvg92Fg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/aws-lambda": "1.120.0",
@@ -159,6 +169,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.120.0.tgz",
       "integrity": "sha512-IYQ4oDYlRDX+obl6Kv2Q3Jn22cm0tRQDE0oHtbHdiTUa7dx60tWBHS+m4wse8j3mmSkOKOsr9sXnhEtD3+zMIg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-certificatemanager": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -177,6 +188,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.120.0.tgz",
       "integrity": "sha512-zGKQ0FRhRdnWuyxjW9cAD4U+PfIc9ylxyP0ipteVmOChHs+HvltImY074STLeH7gGkJUfIo/7TqYG7UKcfTBnQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -187,6 +199,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.120.0.tgz",
       "integrity": "sha512-Mrk7jgtI3QiN85zF4XMKZvuc2kO8qdhNAsNDsYijKm39ymbfHa7mnDYzpYvOtx9nn2IbSG5ndUYjdK+OpLPfpw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-codecommit": "1.120.0",
@@ -209,7 +222,8 @@
       "dependencies": {
         "yaml": {
           "version": "1.10.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -217,6 +231,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.120.0.tgz",
       "integrity": "sha512-C/wS72ZE45ePYW1GpP8Qv2BHK0aipIK2t2Aqr62gly8IvueWlfsqv7eqykGa4gw2vIJV9gHZvCUZOaKDTOqBdg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-codestarnotifications": "1.120.0",
         "@aws-cdk/aws-events": "1.120.0",
@@ -229,6 +244,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.120.0.tgz",
       "integrity": "sha512-cJ6VAJt3HWkgp/3t/1YsjJxo3yLpVrhAelwrEFlvQkfKKyTCD/i+L2eL4MaD2lLPyCCxwK7LKvnr3BgclgKtsg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -239,6 +255,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.120.0.tgz",
       "integrity": "sha512-oGyHDuEY+k+IXyzQMmcyWm9d8fZ9RkvQleITyvn6KsNSOVwsrW2O3it70Z7k6TVHHCHK5O7XvNIEzV+IMdx4fA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-codestarnotifications": "1.120.0",
         "@aws-cdk/aws-events": "1.120.0",
@@ -253,6 +270,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.120.0.tgz",
       "integrity": "sha512-dqbl0vIe2muXzhhoy6lCYKyPl4KNx+N5BQ5avLWj+Rd4NysEKUaAQEGsEX243R9uo0ZJyA4Jo2RYXN+m2b5G2Q==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "constructs": "^3.3.69"
@@ -262,6 +280,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.120.0.tgz",
       "integrity": "sha512-EFFiJuJhRGkVjB4LGWIth5DKnKPL1R2ZLbKsYtTcwnc3UZIbKtHZS6STQd8wYvM0rryagukmS+rdC9l+NmGWJQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-certificatemanager": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -274,7 +293,8 @@
       "dependencies": {
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -282,6 +302,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.120.0.tgz",
       "integrity": "sha512-u6mV15vpWSWwVQZIeY6cJwc+LK3yT4szIeo7rTHFp0+QrGDEUZsFffnn89XszsdNbbDnyam9u3mKuCYoEHlFJg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-applicationautoscaling": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -298,6 +319,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.120.0.tgz",
       "integrity": "sha512-KF47sR3dHeCWkK5Ch6r6Kdf0ZFn8Hme+SgCrv/5PvftYmlJrOLFWb8QNn46Tkd/BZm0IZumCHK4SPDmMSfyXPg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -317,6 +339,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.120.0.tgz",
       "integrity": "sha512-YiF3h4DPxIzV/7muHA9iLgyNSJgPSPhcvcOpW+eatFJbp7LyfIb/m0By9NwxKx1MixSZM4DU+kQbpRxUDXlk3Q==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-events": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -328,6 +351,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.120.0.tgz",
       "integrity": "sha512-LLFM7aAl5QuRb1WqAvAuuVreduLL0uQk8rr9J5gbZSc1Jjjs9TNLVKdtvS7K8VUaZ9unVNvAARm/MXuqOmETeg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/assets": "1.120.0",
         "@aws-cdk/aws-ecr": "1.120.0",
@@ -341,11 +365,13 @@
       "dependencies": {
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -353,11 +379,13 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -368,6 +396,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.120.0.tgz",
       "integrity": "sha512-0C5tbRDs9XKCwo2/PpoW1pePz2xjwuTsMpjnPt3RsDSbPButYCpT9id8ANCODycGvdTknhMu/TT49bOS/7G1Yw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-applicationautoscaling": "1.120.0",
         "@aws-cdk/aws-autoscaling": "1.120.0",
@@ -401,6 +430,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.120.0.tgz",
       "integrity": "sha512-Q1fzHKIP1SS6EFhESM2BPmZ1h0U6hzD9K5z7iMPfmjMRPQeOzXS8VPQdSJuzi++M7+2B5eAITkEI867nmutfkQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -415,6 +445,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.120.0.tgz",
       "integrity": "sha512-arUq1hGx67z9LkI3Q+MIBb5fIFYA60DatdiGtyYFg0YoJtj6fmHgByfowtJLrpv3iDq/UaIn8k392uWL59Be3w==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -425,6 +456,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.120.0.tgz",
       "integrity": "sha512-x4x/9HqOBXlqLmtmKxRGKsgQ1lW3DVJMet8ONahEPsL1zLb2nRiQooJ1b95U6QmIJ6GK88VC+v4TCuiGBBYl0w==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-certificatemanager": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -443,6 +475,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.120.0.tgz",
       "integrity": "sha512-LEPMi9lPO7ywXxrL2Cu2tSr6aivDHYWWNtbNOto4BXWAwy5+BEL4fRujx25XAf0G3b6DJtatGXOM8E9Vnyqk/A==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -453,6 +486,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.120.0.tgz",
       "integrity": "sha512-cCRNc7420D394Fb3k4xowQ8UA2oz/HIHoSDzGm26A0R8Wbgha77sHccYn8Romxj4oz/+GdC1rkptyJ2vqnVwXA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-apigateway": "1.120.0",
         "@aws-cdk/aws-codebuild": "1.120.0",
@@ -479,6 +513,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-eventschemas/-/aws-eventschemas-1.120.0.tgz",
       "integrity": "sha512-jHujrCbUUSgN7paYkBFCP365Sx69BeWNgWamU0Sf9y2irvFtKQqX73sQmOiQcJynzCu+8IMBuoqkdbMxLaIL/w==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "constructs": "^3.3.69"
@@ -488,6 +523,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.120.0.tgz",
       "integrity": "sha512-aknUNWg1CNJgNczIe50nlv2F5AY1D0icZhBAJUhFLKgdXDuG21D3UW3H+8uQ4xlvsb3dSNjp9giYUoyqKK4Fjw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -499,6 +535,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.120.0.tgz",
       "integrity": "sha512-AeZ0z90YONwb/NWPW+xbKnb7eH0olKzI8f5Z7DL0Wex3KpMA7DoRfwdOXs06vQsz4JEJYM1BwzhG3llOMdoJxQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "@aws-cdk/region-info": "1.120.0",
@@ -509,6 +546,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.120.0.tgz",
       "integrity": "sha512-8CxsDscOWAryRz5pkDyx+Pk3wS7J5OUG5q/ych7XE+s6EU6URQOzB4m89JRM18Xj+9JNP8ifc1mnlERPwb2w9A==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -522,6 +560,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.120.0.tgz",
       "integrity": "sha512-0KPXchFX6Cm/N64SizYSvj8FjfWI+QnZ4QsdUPZOwLHsiHdSJS/kgDGqq1ZZYij1KGKcOSYOXZRaO3lGX7qujg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-ec2": "1.120.0",
@@ -540,6 +579,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.120.0.tgz",
       "integrity": "sha512-n57Gt46BxtrBkPikAwbo+S6aIHstPUAVL2J7cJZ/ZiU91HMOkranMCOnYa9IQ4k8coZQAisSMfp6PEJayd9i0A==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/core": "1.120.0",
@@ -551,6 +591,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.120.0.tgz",
       "integrity": "sha512-eQuw91z1vBf6xO7Zkzym/8eOqPIKaBTZ5w82oR54rtFB2V6JTk6PdQkYIRFaumR/lptD2O1rAS0Qml2gccB8Zw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-applicationautoscaling": "1.120.0",
         "@aws-cdk/aws-cloudwatch": "1.120.0",
@@ -577,6 +618,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.120.0.tgz",
       "integrity": "sha512-kUiPmEt4CIq9TsAW0wdwna8os8BQrdCoqqO9J26PpsB5rL/MNlVCYpf6rDBwujEWD/p+8tPgVwWVsz6j73RXyw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -590,6 +632,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.120.0.tgz",
       "integrity": "sha512-i6zrLICYCZZ9Ym55kDgVeTuFBBj1b0gl4xtqsamJdA+rs1rf9tyfqhq0Y5/rWd4u3mgMMFAcgO+PWcMJPkQJHw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -604,6 +647,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.120.0.tgz",
       "integrity": "sha512-o8QcnLlRzII/eAXp9/G3FzAMZBZs5BVJX2CvcYpz32uGw4FVINb8r8nF4pVWK8uLOQdznqzIa3mqZaFuckQAZA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-apigateway": "1.120.0",
         "@aws-cdk/aws-cloudfront": "1.120.0",
@@ -624,6 +668,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.120.0.tgz",
       "integrity": "sha512-arMKYYhXV05JMjytMYpXFyF/2FTjIMcVyjZmSxTvISBzB0GgxGoCHjB/g1oj1w2L3hpV9/lpY8ZqQPuFM5PclA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-events": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -637,6 +682,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.120.0.tgz",
       "integrity": "sha512-+bZskdp/MpbV7A67S4HTVwgFZy6oktgUyMY18iX3gUos3iMfVlg+1jeFwvzzsfxmv37n/z0Y13lfJ3LKMjV3ZA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/assets": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -651,6 +697,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.120.0.tgz",
       "integrity": "sha512-ZBkC7xIR6uvGcPqpnGKt7WALM2EnzshfBWVMdndlGU3oPYqMKfcSAj0VuVR0B81pz+nm1eYnRMECaYsiCtjx3g==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "constructs": "^3.3.69"
@@ -660,6 +707,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.120.0.tgz",
       "integrity": "sha512-wvePcTpKSj9OebhxMCwLURjgaQgZ4BpeVTjSQ68yqhO+vtB3uUPkn/SjAU/n3A6CozyIQVGgbbd/cGYqPFGInQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -675,6 +723,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.120.0.tgz",
       "integrity": "sha512-zsWrs6/4TWGW5K910XbZfiXAwZfs3WUIbTQeIR3q138A3ypPpl4X5V+spOAOIWVurim8hBpCswOG/+awUd72aw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-ec2": "1.120.0",
         "@aws-cdk/aws-elasticloadbalancingv2": "1.120.0",
@@ -687,6 +736,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.120.0.tgz",
       "integrity": "sha512-kRq5tHbnF8QiyjFWHo2QVCeAX/WyWTldp14piqOh6/UdzXYC8mRSFPw/R9+p7fkdAeVVcaQcSXFCkI7i8dQYlg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/core": "1.120.0",
         "constructs": "^3.3.69"
@@ -696,6 +746,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.120.0.tgz",
       "integrity": "sha512-kLW+BwdbFc0wlF19R3ngyEE5L+C73ghDOYCk3S4/6WvWvhuY6KnTjSyaEJ4TikkrXHwWLGbYGo19bQDtRQj1mw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-codestarnotifications": "1.120.0",
@@ -711,6 +762,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.120.0.tgz",
       "integrity": "sha512-UOxtTyU72Pw8KThxpw3YqDzEgh2vHn3JMF9tqVWzAvhJuKOpcVGZqxJdPme5I5pUYEtLAPS0qTTbzsv9FDByJg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/aws-kms": "1.120.0",
@@ -725,6 +777,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.120.0.tgz",
       "integrity": "sha512-YgLSKJ5QnzDtwl4lDdO9XphVIp7IXZv4GPs9h4gC5jJExaEmTx17yTAMrGZ7b4xqS6n9eYKQfoZl9Dp6IsILTQ==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-iam": "1.120.0",
@@ -737,6 +790,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.120.0.tgz",
       "integrity": "sha512-x+4E1P2F5K88mjE99i3Nf1TyxFHrh4rHL/p2Ew1Q3d+8Z+JWqwTPHC95GSZUQeiXWDxlAofFgB4AKwnho4paEA==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-iam": "1.120.0",
         "@aws-cdk/aws-kms": "1.120.0",
@@ -749,6 +803,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.120.0.tgz",
       "integrity": "sha512-Iv1N0TmAUoBxPeQSxGeVElFoD4z7O3sSD+g2q5d7/pVfl1p+8yGVGHW8H+3PQwQJRlbh4fAacse5FU94AN4wlw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudwatch": "1.120.0",
         "@aws-cdk/aws-events": "1.120.0",
@@ -772,6 +827,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.120.0.tgz",
       "integrity": "sha512-W8CfFYLekobHxQ4on/mygfx8HOFIYverUl0LzvNMxzjpvOl5JQVRYG1azDDLRFomuLvw/6RZpJas8nDUi0y4oA==",
+      "dev": true,
       "requires": {
         "jsonschema": "^1.4.0",
         "semver": "^7.3.5"
@@ -779,11 +835,13 @@
       "dependencies": {
         "jsonschema": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -791,13 +849,15 @@
         "semver": {
           "version": "7.3.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -828,6 +888,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.120.0.tgz",
       "integrity": "sha512-BLWySkl1CUhHnatztB15b1u4+t6RYPaq5bQrdClcJq6sqf8p95Sn57sdNSJVfw31+9+m28vWUwfd7p8JnRStmg==",
+      "dev": true,
       "requires": {
         "@aws-cdk/cloud-assembly-schema": "1.120.0",
         "@aws-cdk/cx-api": "1.120.0",
@@ -841,19 +902,23 @@
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "at-least-node": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -861,11 +926,13 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fs-extra": {
           "version": "9.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -875,15 +942,18 @@
         },
         "graceful-fs": {
           "version": "4.2.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ignore": {
           "version": "5.1.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonfile": {
           "version": "6.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -892,13 +962,15 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "universalify": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -906,6 +978,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.120.0.tgz",
       "integrity": "sha512-SjJAD9QQtkRCw3xow6bcTR9Bmn6lldlglbuN8/+JQE0tv+tZTJ3FfGCFR7wEGeni6kS9v7fnAmfTgZbgl7VL9A==",
+      "dev": true,
       "requires": {
         "@aws-cdk/aws-cloudformation": "1.120.0",
         "@aws-cdk/aws-ec2": "1.120.0",
@@ -921,6 +994,7 @@
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.120.0.tgz",
       "integrity": "sha512-ETlLjWyHwLEWEoggTCFs+BVEIFtgxAUHjkVkgYPfqnqFl29C6kQqgcXuOlIfRgisImRSQnWlzHf+6Tse5nR5Jw==",
+      "dev": true,
       "requires": {
         "@aws-cdk/cloud-assembly-schema": "1.120.0",
         "semver": "^7.3.5"
@@ -929,6 +1003,7 @@
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -936,20 +1011,23 @@
         "semver": {
           "version": "7.3.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
     "@aws-cdk/region-info": {
       "version": "1.120.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.120.0.tgz",
-      "integrity": "sha512-DX315Ydn3+QgTodhyPZCQc2WvsKbQ7c/W44DdGv//zabZloTrXcXIeEGWkrUexJOpHPWqD7WLZsDm1uh3Ic4Og=="
+      "integrity": "sha512-DX315Ydn3+QgTodhyPZCQc2WvsKbQ7c/W44DdGv//zabZloTrXcXIeEGWkrUexJOpHPWqD7WLZsDm1uh3Ic4Og==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -3925,7 +4003,8 @@
     "constructs": {
       "version": "3.3.138",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.138.tgz",
-      "integrity": "sha512-Q353/8IuHuQ7syq4MJQVFSnrWSY139QkpMz2dpGMwf4ins26b7DPXsVknP0KuVK+iwsTxnv1wDVxXOmyxAVuIA=="
+      "integrity": "sha512-Q353/8IuHuQ7syq4MJQVFSnrWSY139QkpMz2dpGMwf4ins26b7DPXsVknP0KuVK+iwsTxnv1wDVxXOmyxAVuIA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -15,17 +15,6 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.120.0",
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "aws-cdk": "1.120.0",
-    "aws-sdk": "^2.973.0",
-    "aws-sdk-mock": "^5.2.2",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
-  },
-  "dependencies": {
     "@aws-cdk/aws-apigatewayv2": "1.120.0",
     "@aws-cdk/aws-apigatewayv2-integrations": "1.120.0",
     "@aws-cdk/aws-dynamodb": "1.120.0",
@@ -37,7 +26,30 @@
     "@aws-cdk/aws-sns": "1.120.0",
     "@aws-cdk/aws-sns-subscriptions": "1.120.0",
     "@aws-cdk/aws-sqs": "1.120.0",
-    "@aws-cdk/core": "1.120.0"
+    "@aws-cdk/core": "1.120.0",
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "aws-cdk": "1.120.0",
+    "aws-sdk": "^2.973.0",
+    "aws-sdk-mock": "^5.2.2",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.2.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~3.9.7"
+  },
+  "peerDependencies": {
+    "@aws-cdk/aws-apigatewayv2": "^1.120.0",
+    "@aws-cdk/aws-apigatewayv2-integrations": "^1.120.0",
+    "@aws-cdk/aws-dynamodb": "^1.120.0",
+    "@aws-cdk/aws-events": "^1.120.0",
+    "@aws-cdk/aws-events-targets": "^1.120.0",
+    "@aws-cdk/aws-eventschemas": "^1.120.0",
+    "@aws-cdk/aws-iam": "^1.120.0",
+    "@aws-cdk/aws-lambda": "^1.120.0",
+    "@aws-cdk/aws-sns": "^1.120.0",
+    "@aws-cdk/aws-sns-subscriptions": "^1.120.0",
+    "@aws-cdk/aws-sqs": "^1.120.0",
+    "@aws-cdk/core": "^1.120.0"
   },
   "keywords": [
     "aws",

--- a/test/__snapshots__/cdk-eventbridge-socket.test.ts.snap
+++ b/test/__snapshots__/cdk-eventbridge-socket.test.ts.snap
@@ -5,48 +5,56 @@ Object {
   "Outputs": Object {
     "eventBridgeSocketDeployWebsocketendpoint7B865CDA": Object {
       "Value": Object {
-        "Fn::GetAtt": Array [
-          "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
-          "ApiEndpoint",
+        "Fn::Join": Array [
+          "",
+          Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
+                "ApiEndpoint",
+              ],
+            },
+            "/dev",
+          ],
         ],
       },
     },
   },
   "Parameters": Object {
-    "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4ArtifactHashEE784EBF": Object {
-      "Description": "Artifact hash for asset \\"189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4\\"",
+    "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9ArtifactHash8FE9313B": Object {
+      "Description": "Artifact hash for asset \\"0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9\\"",
       "Type": "String",
     },
-    "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4S3Bucket210A09A6": Object {
-      "Description": "S3 bucket for asset \\"189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4\\"",
+    "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9S3BucketF5637FC3": Object {
+      "Description": "S3 bucket for asset \\"0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9\\"",
       "Type": "String",
     },
-    "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4S3VersionKey996026C1": Object {
-      "Description": "S3 key for asset version \\"189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4\\"",
+    "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9S3VersionKey9EDF8659": Object {
+      "Description": "S3 key for asset version \\"0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9\\"",
       "Type": "String",
     },
-    "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aArtifactHash85421036": Object {
-      "Description": "Artifact hash for asset \\"58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9a\\"",
+    "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefArtifactHash0CEE3A9F": Object {
+      "Description": "Artifact hash for asset \\"0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cef\\"",
       "Type": "String",
     },
-    "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aS3Bucket18FBAF40": Object {
-      "Description": "S3 bucket for asset \\"58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9a\\"",
+    "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefS3Bucket0CDABFD2": Object {
+      "Description": "S3 bucket for asset \\"0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cef\\"",
       "Type": "String",
     },
-    "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aS3VersionKey5C07FCF9": Object {
-      "Description": "S3 key for asset version \\"58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9a\\"",
+    "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefS3VersionKeyFDD215FC": Object {
+      "Description": "S3 key for asset version \\"0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cef\\"",
       "Type": "String",
     },
-    "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aArtifactHash2B2A4443": Object {
-      "Description": "Artifact hash for asset \\"a6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802a\\"",
+    "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4ArtifactHashD218146F": Object {
+      "Description": "Artifact hash for asset \\"4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4\\"",
       "Type": "String",
     },
-    "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aS3BucketE6FA6158": Object {
-      "Description": "S3 bucket for asset \\"a6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802a\\"",
+    "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4S3Bucket6200EC24": Object {
+      "Description": "S3 bucket for asset \\"4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4\\"",
       "Type": "String",
     },
-    "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aS3VersionKey824648E8": Object {
-      "Description": "S3 key for asset version \\"a6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802a\\"",
+    "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4S3VersionKeyB7169A21": Object {
+      "Description": "S3 key for asset version \\"4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4\\"",
       "Type": "String",
     },
   },
@@ -93,23 +101,49 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "eventBridgeSocketDeployconnectlambdaintegrationA9D7FA28": Object {
+    "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47": Object {
+      "Properties": Object {
+        "Name": "EventBridgeSockets",
+        "ProtocolType": "WEBSOCKET",
+        "RouteSelectionExpression": "$request.body.action",
+      },
+      "Type": "AWS::ApiGatewayV2::Api",
+    },
+    "eventBridgeSocketDeployeventBridgeSocketDeployapiconnectRoute308BAAC5": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
         },
-        "CredentialsArn": Object {
-          "Fn::GetAtt": Array [
-            "eventBridgeSocketDeployeventBridgeSocketDeployapiiamrole5B0A9275",
-            "Arn",
+        "RouteKey": "$connect",
+        "Target": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "integrations/",
+              Object {
+                "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiconnectRouteWebSocketIntegration449f455cb3c7748381eb0f0246ccfa2f05649A15",
+              },
+            ],
           ],
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Route",
+    },
+    "eventBridgeSocketDeployeventBridgeSocketDeployapiconnectRouteWebSocketIntegration449f455cb3c7748381eb0f0246ccfa2f05649A15": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
         },
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "arn:aws:apigateway:",
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -127,20 +161,56 @@ Object {
       },
       "Type": "AWS::ApiGatewayV2::Integration",
     },
-    "eventBridgeSocketDeployconnectrouteE4B2A96E": Object {
+    "eventBridgeSocketDeployeventBridgeSocketDeployapiconnectRouteeventBridgeSocketDeployeventBridgeSocketDeployapiconnectRoute969E1C59PermissionE0DAFB7C": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "eventBridgeSocketDeployonconnectAE0ACD17",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
+              },
+              "/*/*$connect",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "eventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRoute5AA2FBC6": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
         },
-        "AuthorizationType": "NONE",
-        "RouteKey": "$connect",
+        "RouteKey": "$disconnect",
         "Target": Object {
           "Fn::Join": Array [
             "",
             Array [
               "integrations/",
               Object {
-                "Ref": "eventBridgeSocketDeployconnectlambdaintegrationA9D7FA28",
+                "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRouteWebSocketIntegration0a84f9265d12d31c9984b952fd3b77202D79D90F",
               },
             ],
           ],
@@ -148,23 +218,21 @@ Object {
       },
       "Type": "AWS::ApiGatewayV2::Route",
     },
-    "eventBridgeSocketDeploydisconnectlambdaintegration96C39EB8": Object {
+    "eventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRouteWebSocketIntegration0a84f9265d12d31c9984b952fd3b77202D79D90F": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
-        },
-        "CredentialsArn": Object {
-          "Fn::GetAtt": Array [
-            "eventBridgeSocketDeployeventBridgeSocketDeployapiiamrole5B0A9275",
-            "Arn",
-          ],
+          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
         },
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "arn:aws:apigateway:",
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -182,113 +250,49 @@ Object {
       },
       "Type": "AWS::ApiGatewayV2::Integration",
     },
-    "eventBridgeSocketDeploydisconnectroute371DB6DD": Object {
+    "eventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRouteeventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRoute1F6837D8Permission67DA007B": Object {
       "Properties": Object {
-        "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "eventBridgeSocketDeployondisconnect0F61A161",
+            "Arn",
+          ],
         },
-        "AuthorizationType": "NONE",
-        "RouteKey": "$disconnect",
-        "Target": Object {
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "integrations/",
+              "arn:",
               Object {
-                "Ref": "eventBridgeSocketDeploydisconnectlambdaintegration96C39EB8",
+                "Ref": "AWS::Partition",
               },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
+              },
+              "/*/*$disconnect",
             ],
           ],
         },
       },
-      "Type": "AWS::ApiGatewayV2::Route",
+      "Type": "AWS::Lambda::Permission",
     },
-    "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039": Object {
-      "Properties": Object {
-        "Name": "EventBridgeSockets",
-        "ProtocolType": "WEBSOCKET",
-        "RouteSelectionExpression": "$request.body.action",
-      },
-      "Type": "AWS::ApiGatewayV2::Api",
-    },
-    "eventBridgeSocketDeployeventBridgeSocketDeployapideploymentBB543A98": Object {
-      "DependsOn": Array [
-        "eventBridgeSocketDeployconnectrouteE4B2A96E",
-        "eventBridgeSocketDeploydisconnectroute371DB6DD",
-      ],
+    "eventBridgeSocketDeployeventBridgeSocketDeployapistage6E463CF6": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::Deployment",
-    },
-    "eventBridgeSocketDeployeventBridgeSocketDeployapiiamrole5B0A9275": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "eventBridgeSocketDeployeventBridgeSocketDeployapiiamroleDefaultPolicy11C8AA27": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "eventBridgeSocketDeployonconnectAE0ACD17",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::GetAtt": Array [
-                    "eventBridgeSocketDeployondisconnect0F61A161",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::GetAtt": Array [
-                    "eventBridgeSocketDeployeventbridgebroker1D8651C6",
-                    "Arn",
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "eventBridgeSocketDeployeventBridgeSocketDeployapiiamroleDefaultPolicy11C8AA27",
-        "Roles": Array [
-          Object {
-            "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiiamrole5B0A9275",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "eventBridgeSocketDeployeventBridgeSocketDeployapistage1336E4D7": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
         },
         "AutoDeploy": true,
-        "DeploymentId": Object {
-          "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapideploymentBB543A98",
-        },
         "StageName": "dev",
       },
       "Type": "AWS::ApiGatewayV2::Stage",
@@ -325,7 +329,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4S3Bucket210A09A6",
+            "Ref": "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9S3BucketF5637FC3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -338,7 +342,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4S3VersionKey996026C1",
+                          "Ref": "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9S3VersionKey9EDF8659",
                         },
                       ],
                     },
@@ -351,7 +355,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters189f2c91281e177eada2df4ac00eb351945e4c57f6d22baffa28e6838cf9d8f4S3VersionKey996026C1",
+                          "Ref": "AssetParameters0465dbaf624c7c75707a7059f7f4d57a99144d52abf74b0056954cb5c4f730f9S3VersionKey9EDF8659",
                         },
                       ],
                     },
@@ -370,7 +374,7 @@ Object {
                 Array [
                   Object {
                     "Fn::GetAtt": Array [
-                      "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+                      "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
                       "ApiEndpoint",
                     ],
                   },
@@ -414,7 +418,7 @@ Object {
                     },
                     ":",
                     Object {
-                      "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapi37537039",
+                      "Ref": "eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47",
                     },
                     "/*",
                   ],
@@ -499,7 +503,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aS3Bucket18FBAF40",
+            "Ref": "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4S3Bucket6200EC24",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -512,7 +516,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aS3VersionKey5C07FCF9",
+                          "Ref": "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4S3VersionKeyB7169A21",
                         },
                       ],
                     },
@@ -525,7 +529,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters58b44f089530a411338be00d6a42306e54315ad4296be77451fa81c7742b2a9aS3VersionKey5C07FCF9",
+                          "Ref": "AssetParameters4093a22ea6ccf39bbe5a10a1aaff656ed40dce829d913111c9b1a37877f1f8a4S3VersionKeyB7169A21",
                         },
                       ],
                     },
@@ -635,7 +639,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aS3BucketE6FA6158",
+            "Ref": "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefS3Bucket0CDABFD2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -648,7 +652,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aS3VersionKey824648E8",
+                          "Ref": "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefS3VersionKeyFDD215FC",
                         },
                       ],
                     },
@@ -661,7 +665,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa6c413ff98ccb54bd991dedcc0fab2635afc75162f4f3b980e2906d1e87d802aS3VersionKey824648E8",
+                          "Ref": "AssetParameters0bffb408a9c50735b5bd38bd55f84a27977a0ee2f1506ba94759f266593d9cefS3VersionKeyFDD215FC",
                         },
                       ],
                     },

--- a/test/cdk-eventbridge-socket.test.ts
+++ b/test/cdk-eventbridge-socket.test.ts
@@ -1,4 +1,8 @@
-import { SynthUtils, expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
+import {
+  SynthUtils,
+  expect as expectCDK,
+  haveResourceLike,
+} from '@aws-cdk/assert';
 import { Stack } from '@aws-cdk/core';
 import { EventBridgeWebSocket } from '../lib';
 
@@ -38,18 +42,28 @@ describe('EventBridgeWebSocket', () => {
     // on connect integration
     expectCDK(stack).to(
       haveResourceLike('AWS::ApiGatewayV2::Integration', {
+        ApiId: {
+          Ref: 'eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47',
+        },
         IntegrationType: 'AWS_PROXY',
         IntegrationUri: {
           'Fn::Join': [
             '',
             [
-              'arn:aws:apigateway:',
+              'arn:',
+              {
+                Ref: 'AWS::Partition',
+              },
+              ':apigateway:',
               {
                 Ref: 'AWS::Region',
               },
               ':lambda:path/2015-03-31/functions/',
               {
-                'Fn::GetAtt': ['eventBridgeSocketDeployonconnectAE0ACD17', 'Arn'],
+                'Fn::GetAtt': [
+                  'eventBridgeSocketDeployonconnectAE0ACD17',
+                  'Arn',
+                ],
               },
               '/invocations',
             ],
@@ -60,6 +74,9 @@ describe('EventBridgeWebSocket', () => {
 
     // expectCDK(stack).to(
     haveResourceLike('AWS::ApiGatewayV2::Route', {
+      ApiId: {
+        Ref: 'eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47',
+      },
       RouteKey: '$connect',
       Target: {
         'Fn::Join': [
@@ -76,18 +93,28 @@ describe('EventBridgeWebSocket', () => {
 
     expectCDK(stack).to(
       haveResourceLike('AWS::ApiGatewayV2::Integration', {
+        ApiId: {
+          Ref: 'eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47',
+        },
         IntegrationType: 'AWS_PROXY',
         IntegrationUri: {
           'Fn::Join': [
             '',
             [
-              'arn:aws:apigateway:',
+              'arn:',
+              {
+                Ref: 'AWS::Partition',
+              },
+              ':apigateway:',
               {
                 Ref: 'AWS::Region',
               },
               ':lambda:path/2015-03-31/functions/',
               {
-                'Fn::GetAtt': ['eventBridgeSocketDeployondisconnect0F61A161', 'Arn'],
+                'Fn::GetAtt': [
+                  'eventBridgeSocketDeployondisconnect0F61A161',
+                  'Arn',
+                ],
               },
               '/invocations',
             ],
@@ -98,6 +125,9 @@ describe('EventBridgeWebSocket', () => {
 
     expectCDK(stack).to(
       haveResourceLike('AWS::ApiGatewayV2::Route', {
+        ApiId: {
+          Ref: 'eventBridgeSocketDeployeventBridgeSocketDeployapiA13E2D47',
+        },
         RouteKey: '$disconnect',
         Target: {
           'Fn::Join': [
@@ -105,7 +135,7 @@ describe('EventBridgeWebSocket', () => {
             [
               'integrations/',
               {
-                Ref: 'eventBridgeSocketDeploydisconnectlambdaintegration96C39EB8',
+                Ref: 'eventBridgeSocketDeployeventBridgeSocketDeployapidisconnectRouteWebSocketIntegration0a84f9265d12d31c9984b952fd3b77202D79D90F',
               },
             ],
           ],


### PR DESCRIPTION
Fixes https://github.com/boyney123/cdk-eventbridge-socket/issues/4

I noticed this project had pinned CDK dependencies to 1.120.0. When those are listed as direct dependencies, all consumers of the lib need to use that exact version. It's a bummer for CDK which will be fixed with the 2.0 version. For now, it's a better practice to list those dependencies as peerDependencies which lets the consumer install their own versions and warns them if they don't (npm 7 does [this](https://github.com/npm/rfcs/blob/latest/implemented/0025-install-peer-deps.md) instead).

Also looks like some churn in the test snapshots. You might get more stability using the [NodejsFunction](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-nodejs.NodejsFunction.html) construct.