### PR TITLE
feat: make websocket endpoint available as prop

### DIFF
--- a/lib/eventbridge-sockets/eventbridge-sockets-contruct.ts
+++ b/lib/eventbridge-sockets/eventbridge-sockets-contruct.ts
@@ -95,6 +95,8 @@ export class EventBridgeWebSocket extends Construct {
     });
 
     new CfnOutput(this, 'Websocket endpoint', { value: `${api.apiEndpoint}/${config?.stage}` });
+    
+    this.websocketEndpoint = `${api.apiEndpoint}/${config?.stage}`;
   }
 
   private createFunction(name: string, tableName: string, options: any = {}) {


### PR DESCRIPTION
We have a use case where we want to use the websocket endpoint URL in another construct, AFAIK `CfnOutput` doesn't make this available. This allows something like:
```ts
const websocket = new EventBridgeWebSocket(this, 'sockets', {
  bus: `my-bus-${props.stage}`,

  eventPattern: {
    source: ['my-source'],
  },
  stage:props.stage,
});

console.log(websocket.websocketEndpoint);
```

Now wondering if just `endpoint` would be better...