### PR TITLE
Add apiKey authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+example/**/*.js
 lib/**/*.js
 test/**/*.js
 !jest.config.js

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ new EventBridgeWebSocket(this, 'sockets', {
 });
 ```
 
+##### Secure api with apikey
+
+```typescript
+new EventBridgeWebSocket(this, 'sockets', {
+  bus: 'your-event-bus-name',
+
+  // Listens for all UserCreated events
+  eventPattern: {
+    detailType: ['UserCreated'],
+  },
+  stage: 'dev',
+  authentication: true,
+});
+```
+
+This will create an aws secret in the secretsmanager with the api key used for authentication. The apikey must be added as query param to the api endpoint url `wss://<apiId>.execute-api.<region>.amazonaws.com/<stage>?apiKey=<valueFromSecret>`
+
 You can find more [here on the AWS documentation](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-events.EventPattern.html)
 
 # Contributing

--- a/example/event-publisher.ts
+++ b/example/event-publisher.ts
@@ -1,0 +1,17 @@
+import { EventBridge } from 'aws-sdk';
+import { randomUUID } from 'crypto';
+
+var events = new EventBridge();
+export const handler = async () => {
+  var params = {
+    Entries: [
+      {
+        Detail: JSON.stringify({ timestamp: new Date().toLocaleDateString(), payload: randomUUID() }),
+        DetailType: 'ExampleEvent',
+        EventBusName: process.env.EVENT_BUS_NAME,
+        Source: 'example.event.source',
+      },
+    ],
+  };
+  await events.putEvents(params).promise();
+};

--- a/example/example-app.ts
+++ b/example/example-app.ts
@@ -1,0 +1,36 @@
+import { App, Duration, Stack } from 'aws-cdk-lib';
+import { EventBus, Rule, Schedule } from 'aws-cdk-lib/aws-events';
+import { AwsApi, LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { EventBridgeWebSocket } from '../lib';
+
+const app = new App();
+
+const stack = new Stack(app, 'example-stack');
+
+const eventbus = new EventBus(stack, 'EventBus');
+
+const eventPublisher = new NodejsFunction(stack, 'EventPublisher', {
+  entry: 'example/event-publisher.ts',
+  runtime: Runtime.NODEJS_16_X,
+  environment: {
+    EVENT_BUS_NAME: eventbus.eventBusName,
+  },
+});
+eventbus.grantPutEventsTo(eventPublisher);
+
+new Rule(stack, 'Rule', {
+  schedule: Schedule.rate(Duration.minutes(1)),
+  targets: [new LambdaFunction(eventPublisher)],
+});
+
+new EventBridgeWebSocket(stack, 'EventBridgeWebSocket', {
+  bus: eventbus.eventBusName,
+
+  eventPattern: {
+    source: ['example.event.source'],
+  },
+  stage: 'test',
+  authentication: true,
+});

--- a/lib/eventbridge-sockets/eventbridge-sockets-contruct.ts
+++ b/lib/eventbridge-sockets/eventbridge-sockets-contruct.ts
@@ -109,7 +109,7 @@ export class EventBridgeWebSocket extends Construct {
   }
 
   private addAuthorization() {
-    const apiKeySecret = new Secret(this, 'apiKeySecret');
+    const apiKeySecret = new Secret(this, 'apiKeySecret', { removalPolicy: RemovalPolicy.DESTROY });
     const authorizerLambda = new NodejsFunction(this, 'authorizer', {
       entry: path.join(__dirname, '../lambda-fns/authorizer/authorizer.ts'),
       runtime: Runtime.NODEJS_16_X,

--- a/lib/lambda-fns/authorizer/authorizer.ts
+++ b/lib/lambda-fns/authorizer/authorizer.ts
@@ -1,0 +1,39 @@
+import { getSecretValue } from './secretsmanager';
+
+type ApigatewayWebsocketLambdaAuthorizerEvent = {
+  headers: Record<string, string>;
+  queryStringParameters: Record<string, string>;
+  methodArn: string;
+};
+export const handler = async ({ methodArn, queryStringParameters }: ApigatewayWebsocketLambdaAuthorizerEvent) => {
+  // Retrieve request parameters from the Lambda function input:
+
+  if (!queryStringParameters || queryStringParameters == null) {
+    console.log('No queryStringParameters found');
+    return 'Unauthorized';
+  }
+
+  const apiKey = await getSecretValue();
+
+  if (queryStringParameters['apiKey'] !== apiKey) {
+    console.log("API Key doesn't match");
+    return 'Unauthorized';
+  }
+  const apigatewayAuthorizerAllowPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Action: 'execute-api:Invoke',
+        Effect: 'Allow',
+        Resource: methodArn,
+      },
+    ],
+  };
+  console.log('Access granted');
+  const resp = {
+    principalId: 'authenticated-user',
+    policyDocument: apigatewayAuthorizerAllowPolicy,
+  };
+  console.log(JSON.stringify(resp));
+  return resp;
+};

--- a/lib/lambda-fns/authorizer/secretsmanager.ts
+++ b/lib/lambda-fns/authorizer/secretsmanager.ts
@@ -1,0 +1,11 @@
+import { SecretsManager } from 'aws-sdk';
+
+const secretClient = new SecretsManager();
+
+export const getSecretValue = async (): Promise<string> => {
+  const secretString = await (await secretClient.getSecretValue({ SecretId: process.env.API_KEY_SECRET! }).promise()).SecretString;
+  if (!secretString) {
+    throw new Error(`Secret string not found in secret ${process.env.API_KEY_SECRET}`);
+  }
+  return secretString;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "cdk-eventbridge-socket",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-eventbridge-socket",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "^2.45.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.45.0-alpha.0",
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.45.0-alpha.0",
         "aws-cdk-lib": "^2.45.0",
         "constructs": "^10.1.127",
@@ -66,6 +67,19 @@
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
+        "aws-cdk-lib": "^2.45.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
+      "version": "2.45.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.45.0-alpha.0.tgz",
+      "integrity": "sha512-W0lIJMM5JH0l1yG2rWJGzANXqH0657bfa9N59RRA8iYRrTg/9zA2dJZDRzRbAIKRpkVwLGVqEeVZVqJDWcAWcA==",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.45.0-alpha.0",
         "aws-cdk-lib": "^2.45.0",
         "constructs": "^10.0.0"
       }
@@ -5398,6 +5412,12 @@
       "version": "2.45.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.45.0-alpha.0.tgz",
       "integrity": "sha512-aqxMqA+6MUFT2OewgMpKg4cdwb5wvIPeS6n+fsKIRsmrRQuiZZDCEk6OFD+a+ObHl/sFNIv7NUeJSlvJhM12RQ==",
+      "requires": {}
+    },
+    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
+      "version": "2.45.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.45.0-alpha.0.tgz",
+      "integrity": "sha512-W0lIJMM5JH0l1yG2rWJGzANXqH0657bfa9N59RRA8iYRrTg/9zA2dJZDRzRbAIKRpkVwLGVqEeVZVqJDWcAWcA==",
       "requires": {}
     },
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
+    "cdk-example": "cdk --app 'ts-node example/example-app.ts'",
     "bump:lib": "npm --no-git-tag-version --allow-same-version version $VERSION"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.45.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.45.0-alpha.0",
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.45.0-alpha.0",
     "aws-cdk-lib": "^2.45.0",
     "constructs": "^10.1.127",

--- a/test/__snapshots__/cdk-eventbridge-socket.test.ts.snap
+++ b/test/__snapshots__/cdk-eventbridge-socket.test.ts.snap
@@ -270,16 +270,13 @@ exports[`EventBridgeWebSocket snapshot test EventsRuleToSns default params 1`] =
             "AttributeType": "S",
           },
         ],
+        "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
             "AttributeName": "connectionId",
             "KeyType": "HASH",
           },
         ],
-        "ProvisionedThroughput": {
-          "ReadCapacityUnits": 5,
-          "WriteCapacityUnits": 5,
-        },
         "TableName": "eventBridgeSocketDeploy-connections-table",
       },
       "Type": "AWS::DynamoDB::Table",
@@ -295,7 +292,7 @@ exports[`EventBridgeWebSocket snapshot test EventsRuleToSns default params 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e0a0f754714a39c50b8d4b23a69e2ffea1ff6f186f10c257f57b04f17740569.zip",
+          "S3Key": "a549b85065ed6603d1aac6495ead30df29d29dab7ce01adb9c4f9d7c376fe472.zip",
         },
         "Environment": {
           "Variables": {
@@ -325,7 +322,7 @@ exports[`EventBridgeWebSocket snapshot test EventsRuleToSns default params 1`] =
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -455,7 +452,7 @@ exports[`EventBridgeWebSocket snapshot test EventsRuleToSns default params 1`] =
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -561,7 +558,7 @@ exports[`EventBridgeWebSocket snapshot test EventsRuleToSns default params 1`] =
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",

--- a/test/lambdas/authorizer.test.ts
+++ b/test/lambdas/authorizer.test.ts
@@ -1,0 +1,53 @@
+import { handler } from '../../lib/lambda-fns/authorizer/authorizer';
+import * as secretsmanager from '../../lib/lambda-fns/authorizer/secretsmanager';
+
+describe('authorizer', () => {
+  it('return allow policy for method arn if apiKey match', async () => {
+    jest.spyOn(secretsmanager, 'getSecretValue').mockResolvedValue('some-api-key');
+    const event = {
+      headers: {},
+      queryStringParameters: {
+        apiKey: 'some-api-key',
+      },
+      methodArn: 'arn:aws:execute-api:us-east-1:123456789012:11111/prod/$connect',
+    };
+    const response = await handler(event);
+    expect(response).toEqual({
+      principalId: 'authenticated-user',
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'execute-api:Invoke',
+            Effect: 'Allow',
+            Resource: 'arn:aws:execute-api:us-east-1:123456789012:11111/prod/$connect',
+          },
+        ],
+      },
+    });
+  });
+
+  it("should return 'Unauthorized' if apiKey doesn't match", async () => {
+    jest.spyOn(secretsmanager, 'getSecretValue').mockResolvedValue('some-api-key');
+    const event = {
+      headers: {},
+      queryStringParameters: {
+        apiKey: 'wrong-api-key',
+      },
+      methodArn: 'arn:aws:execute-api:us-east-1:123456789012:11111/prod/$connect',
+    };
+    const response = await handler(event);
+    expect(response).toEqual('Unauthorized');
+  });
+
+  it("should return 'Unauthorized' if apiKey is missing", async () => {
+    jest.spyOn(secretsmanager, 'getSecretValue').mockResolvedValue('some-api-key');
+    const event = {
+      headers: {},
+      queryStringParameters: {},
+      methodArn: 'arn:aws:execute-api:us-east-1:123456789012:11111/prod/$connect',
+    };
+    const response = await handler(event);
+    expect(response).toEqual('Unauthorized');
+  });
+});


### PR DESCRIPTION
This PR adds a new config flag to secure the api with an apikey. 
fixes #1 
The apikey is generated and stored in the aws secretsmanager and checked at each client connect attempt.
The apikey can be set by adding a queryParam `apiKey=<valueFromSecret>`. 

I decided to go with a query parameter because headers can not allways be set e.g. the browser websocket implementation does not support it. 

The apiKey can be changed by altering the value of the apiKey secret. 

Additionally I added an example cdk app that creates an eventbus and publishes an event every minute. 